### PR TITLE
Change the small random eval component from 3 to 14 (0b1110)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -56,7 +56,7 @@ namespace {
             + (pos.count<QUEEN>(WHITE) - pos.count<QUEEN>(BLACK)) * 9;
 
     vv *= PawnValueEg;
-    vv += Value(2 * (pos.this_thread()->nodes & 3) - 3);
+    vv += Value(2 * (pos.this_thread()->nodes & 14) - 14);
 
     return  Value(pos.side_to_move() == WHITE ? vv : -vv);
   }


### PR DESCRIPTION
Passed cutechess STC:
Score of RF 14 vs RF 3: 1124 - 536 - 1130  [0.605] 2790
...      RF 14 playing White: 620 - 246 - 530  [0.634] 1396
...      RF 14 playing Black: 504 - 290 - 600  [0.577] 1394
...      White vs Black: 910 - 750 - 1130  [0.529] 2790
Elo difference: 74.3 +/- 10.0, LOS: 100.0 %, DrawRatio: 40.5 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted

Passed cutechess LTC:
Score of RF 14 vs RF 3: 875 - 355 - 1062  [0.613] 2292
...      RF 14 playing White: 519 - 153 - 475  [0.660] 1147
...      RF 14 playing Black: 356 - 202 - 587  [0.567] 1145
...      White vs Black: 721 - 509 - 1062  [0.546] 2292
Elo difference: 80.2 +/- 10.4, LOS: 100.0 %, DrawRatio: 46.3 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted

Bench: 4918790